### PR TITLE
Fixed issue when stubbing or returning a struct by cherry-picking specific commit

### DIFF
--- a/Source/Changes.txt
+++ b/Source/Changes.txt
@@ -3,6 +3,11 @@ commit messages and/or the pull requests.
 
 (unreleased)
 
+* OCMock now requires iOS 8 as minimum deployment target
+* Managed objects can now be mocked (Alan Fineberg, Kyle Van Essen)
+* Now considering structs with unknown names to be the same type as a named
+  struct, as long as either the actual definition matches or one of them is
+  opaque.
 * Fixed bug causing verifyWithDelay to be held up by rejects (Nikolay Kasyanov)
 
 

--- a/Source/OCMock/OCMFunctions.m
+++ b/Source/OCMock/OCMFunctions.m
@@ -126,6 +126,10 @@ CFNumberType OCMNumberTypeForObjCType(const char *objcType)
  * compared textually.  This can happen particularly for pointers to such structures, which still
  * encode what is being pointed to.
  *
+ * In addition, this funtion will consider structures with unknown names, encoded as "{?=}, equal to
+ * structures with any name. This means that "{?=dd}" and "{foo=dd}", and even "{?=}" and "{foo=dd}",
+ * are considered equal.
+ *
  * For some types some runtime functions throw exceptions, which is why we wrap this in an
  * exception handler just below.
  */
@@ -159,8 +163,9 @@ static BOOL OCMEqualTypesAllowingOpaqueStructsInternal(const char *type1, const 
             intptr_t type1NameLen = type1NameEnd - type1;
             intptr_t type2NameLen = type2NameEnd - type2;
 
-            /* If the names are not equal, return NO */
-            if (type1NameLen != type2NameLen || strncmp(type1, type2, type1NameLen))
+            /* If the names are not equal and neither of the names is a question mark, return NO */
+            if ((type1NameLen != type2NameLen || strncmp(type1, type2, type1NameLen)) &&
+                !((type1NameLen == 2) && (type1[1] == '?')) && !((type2NameLen == 2) && (type2[1] == '?')))
                 return NO;
 
             /* If the same name, and at least one is opaque, that is close enough. */

--- a/Source/OCMockTests/OCMBoxedReturnValueProviderTests.m
+++ b/Source/OCMockTests/OCMBoxedReturnValueProviderTests.m
@@ -81,6 +81,19 @@
 	XCTAssertTrue([boxed isMethodReturnType:type1 compatibleWithValueType:type2]);
 }
 
+
+- (void)testCorrectEqualityForStructureWithUnknownName
+{
+    // see https://github.com/erikdoe/ocmock/issues/333
+    const char *type1 = "{?=dd}";
+    const char *type2 = "{CLLocationCoordinate2D=dd}";
+
+    OCMBoxedReturnValueProvider *boxed = [OCMBoxedReturnValueProvider new];
+    XCTAssertTrue([boxed isMethodReturnType:type1 compatibleWithValueType:type2]);
+
+}
+
+
 @end
 
 


### PR DESCRIPTION
Here's the original discussion -> https://github.com/erikdoe/ocmock/issues/322